### PR TITLE
Update train.py

### DIFF
--- a/code/yolo3/train.py
+++ b/code/yolo3/train.py
@@ -62,7 +62,7 @@ class AdvLossModel(tf.keras.Model):
                         "Training data",
                         tf.cast(batch[0] * 255, tf.uint8),
                         max_outputs=8)
-            per_replica_loss = self._distribution_strategy.experimental_run_v2(
+            per_replica_loss = self._distribution_strategy.run(
                 self._train_step if step else self._val_step, args=(batch,))
             total_loss += self._distribution_strategy.reduce(
                 tf.distribute.ReduceOp.SUM, per_replica_loss,


### PR DESCRIPTION
Fixed erroneuous legacy function call for strategy "experimental_run_v2" by replacing with supported "run" function to be compatable with TF 2.9.x